### PR TITLE
Feat: hook prepared requests

### DIFF
--- a/requests/hooks.py
+++ b/requests/hooks.py
@@ -8,15 +8,15 @@ Available hooks:
 
 ``response``:
     The response generated from a Request.
+``prepared``:
+    The PreparedResponse object.
 """
-HOOKS = ["response"]
+HOOKS = ["response", "prepared"]
 
 
 def default_hooks():
     return {event: [] for event in HOOKS}
 
-
-# TODO: response is the only one
 
 
 def dispatch_hook(key, hooks, hook_data, **kwargs):

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -89,18 +89,22 @@ def merge_setting(request_setting, session_setting, dict_class=OrderedDict):
 
 
 def merge_hooks(request_hooks, session_hooks, dict_class=OrderedDict):
-    """Properly merges both requests and session hooks.
-
-    This is necessary because when request_hooks == {'response': []}, the
-    merge breaks Session hooks entirely.
+    """ Merges request and session hooks. If both request and session set callables
+    for a given hook, session hooks are overridden.
     """
-    if session_hooks is None or session_hooks.get("response") == []:
+    if session_hooks is None:
         return request_hooks
 
-    if request_hooks is None or request_hooks.get("response") == []:
+    if request_hooks is None:
         return session_hooks
 
-    return merge_setting(request_hooks, session_hooks, dict_class)
+    hooks = default_hooks()
+    for k in hooks:
+        s_v = session_hooks.get(k, None)
+        r_v = request_hooks.get(k, None)
+        hooks[k] = r_v if r_v else s_v
+
+    return dict_class(to_key_val_list(hooks))
 
 
 class SessionRedirectMixin:

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -480,6 +480,8 @@ class Session(SessionRedirectMixin):
         if self.trust_env and not auth and not self.auth:
             auth = get_netrc_auth(request.url)
 
+        hooks = merge_hooks(request.hooks, self.hooks)
+
         p = PreparedRequest()
         p.prepare(
             method=request.method.upper(),
@@ -493,8 +495,12 @@ class Session(SessionRedirectMixin):
             params=merge_setting(request.params, self.params),
             auth=merge_setting(auth, self.auth),
             cookies=merged_cookies,
-            hooks=merge_hooks(request.hooks, self.hooks),
+            hooks=hooks,
         )
+
+        # PreparedRequest manipulation hooks
+        p = dispatch_hook("prepared", hooks, p)
+
         return p
 
     def request(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -16,7 +16,8 @@ def hook(value):
 )
 def test_hooks(hooks_list, result):
     assert hooks.dispatch_hook("response", {"response": hooks_list}, "Data") == result
+    assert hooks.dispatch_hook("prepared", {"prepared": hooks_list}, "Data") == result
 
 
 def test_default_hooks():
-    assert hooks.default_hooks() == {"response": []}
+    assert hooks.default_hooks() == {"response": [], "prepared": []}

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1105,6 +1105,14 @@ class TestRequests:
         assert r.status_code == 200
         assert b"text/py-content-type" in r.request.body
 
+    def test_hook_prepared_receives_prepared_request_obj(self, httpbin):
+        def hook(prepared_request, **kwargs):
+            assert isinstance(prepared_request, PreparedRequest)
+
+        s = requests.Session()
+        r = requests.Request('GET', httpbin(), hooks={'prepared': hook})
+        s.prepare_request(r)
+
     def test_hook_receives_request_arguments(self, httpbin):
         def hook(resp, **kwargs):
             assert resp is not None


### PR DESCRIPTION
**Summary**

This PR adds a `prepared` hook that is called after Prepared Requests are instantiated.

**Motivation**

Generally, hooks are useful for patching functionality that's nested arbitrarily deep within sub-modules. This is especially useful when these sub-modules are 3rd party dependencies and editing the logic directly is not maintainable simply.  

In the case of the newly proposed `prepared` hook, I need to verify whether a sub-module's requests contain the correct headers. The headers values are set across multiple files, and rather than patching each one to verify correctness, I simply hook `prepared` to raise an exception if the headers are incorrect.

**Issues**

Hook effects are generally harder for developers to trace.  However this is not inherent to the `prepared` hook.

**Tasks**
- [x] Write feat tests
- [x] Implement
- [x] Tests pass
- [ ] Update docs
- [ ] Add robustness tests